### PR TITLE
Update to UCX 1.19, PSMPI 5.12.1-2 and PSCOM 5.9.1-1 (linux-64 only)

### DIFF
--- a/recipe/fix-headers.patch
+++ b/recipe/fix-headers.patch
@@ -1,0 +1,10 @@
+--- ./lib/pscom/pscom_dprint.c
++++ ./lib/pscom/pscom_dprint.c
+@@ -14,7 +14,6 @@
+ #include <signal.h>
+ #include <stdarg.h>
+ #include <stdio.h>
+-#include <bits/types/cookie_io_functions_t.h>
+ #include <stdlib.h>
+ #include <string.h>
+ #include <sys/time.h>

--- a/recipe/fix-pscom-macros.patch
+++ b/recipe/fix-pscom-macros.patch
@@ -1,0 +1,22 @@
+--- ./lib/pscom/getid.c
++++ ./lib/pscom/getid.c
+@@ -32,8 +32,8 @@
+ 
+ static char vcid2[] __attribute__((unused)) = "$Id$";
+ 
+-#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+-#define MAX(a, b) (((a) > (b)) ? (a) : (b))
++#define PSCOM_MIN(a, b) (((a) < (b)) ? (a) : (b))
++#define PSCOM_MAX(a, b) (((a) > (b)) ? (a) : (b))
+ 
+ static in_addr_t psp_hostip(char *name)
+ {
+@@ -110,7 +110,7 @@
+ 
+     if (ioctl(sfd, SIOCGIFCONF, &ifc) < 0) { goto error; }
+ 
+-    for (i = 0; i < MIN(IFREQCNT, ifc.ifc_len / sizeof(struct ifreq)); i++) {
++    for (i = 0; i < PSCOM_MIN(IFREQCNT, ifc.ifc_len / sizeof(struct ifreq)); i++) {
+         struct ifreq *req = &ifc.ifc_ifcu.ifcu_req[i];
+ 
+         /* Up ? */

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,22 +1,25 @@
-{% set version = "5.10.0" %}
-{% set pscom_version = "5.8.0" %}
+{% set version = "5.12.1" %}
+{% set pscom_version = "5.9.1" %}
 
 package:
   name: psmpi
   version: {{ version }}
 
 source:
-  - url: https://github.com/ParaStation/psmpi/archive/refs/tags/{{ version }}-1.tar.gz
-    sha256: c05a0281934dc54dc1178df997481a9be4b5b3cc7d5aa515f55d9f7df3f491dc
+  - url: https://github.com/ParaStation/psmpi/archive/refs/tags/{{ version }}-2.tar.gz
+    sha256: 1989a1e13770c23db08d8e5e3fddee798bd782716f3aa86a34b52e9c6a220bbe
     folder: psmpi
   - url: https://github.com/ParaStation/pscom/archive/refs/tags/{{ pscom_version }}-1.tar.gz
-    sha256: e07759bf6efb99c15e9e2a77f32a27af71e0e0438813eaa589ab03d3d0683eca
+    sha256: 8fed647151e64072ca8b6903a5101529562783ec81aa0e60fcc59fd08444d454
     folder: pscom
+    patches:
+      - fix-headers.patch 
+      - fix-pscom-macros.patch
 
 build:
-  number: 6
+  number: 0
   run_exports:
-    - {{ pin_subpackage('psmpi', max_pin='x.y') }}
+    - {{ pin_subpackage('psmpi', max_pin='x.y.z') }}
   skip: true  # [win or osx]
 
 requirements:
@@ -24,15 +27,17 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}
-    - {{ stdlib("c") }} 
+#   - {{ stdlib("c") }}
+    - sysroot_linux-aarch64 >=2.17
     - autoconf
     - automake
     - cmake
     - libtool
     - make
+    - pkg-config
   host:
     - libhwloc
-    - libpmix-devel 
+    - libpmix-devel
     - ucx
   run:
     - {{ compiler('c') }}
@@ -48,7 +53,7 @@ test:
   commands:
     - mpichversion
     - mpifort -o hello_world_mpi hello_world_mpi.f90
-    - ./hello_world_mpi
+    - test -f $PREFIX/lib/libmpi.so
 
 about:
   home: https://github.com/ParaStation/psmpi


### PR DESCRIPTION
This PR is to update to UCX 1.19, PSMPI 5.12.1-2 and PSCOM 5.9.1-1
It is for `linux-64` only, for now, since building for `linux-aarch64` fails on CI (time out)

@conda-forge-admin, please rerender

-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
