### PR TITLE
Add prrte

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
       - fix-pscom-macros.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('psmpi', max_pin='x.y.z') }}
   skip: true  # [win or osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,7 @@ requirements:
   host:
     - libhwloc
     - libpmix-devel
+    - prrte
     - ucx
   run:
     - {{ compiler('c') }}
@@ -45,6 +46,7 @@ requirements:
     - {{ compiler('fortran') }}
     - libhwloc
     - libpmix
+    - prrte
     - ucx
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,8 +27,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}
-#   - {{ stdlib("c") }}
-    - sysroot_linux-aarch64 >=2.17
+    - {{ stdlib("c") }}
     - autoconf
     - automake
     - cmake


### PR DESCRIPTION
This PR adds prrte (PMIx Reference RunTime Environment) as a dependency to the ParaStationMPI recipe to enable the Distributed Virtual Machine (DVM) required for prun-based MPI job execution.


-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
