### PR TITLE
Force rebuild for linux-64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,6 @@ requirements:
     - git
     - libtool
     - make
-    - pkg-config
   host:
     - libhwloc
     - libpmix-devel


### PR DESCRIPTION
This PR is just to force rebuild since the linux-64 version was not created before.
I did not bump up the build number to keep it the same as the linux-aarch64.

-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
